### PR TITLE
Add initial support for running from Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+config.json
+.env*
+*.md
+*.yml

--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,1 @@
+RANKER_TOKEN=tokengoeshere

--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,6 @@ ASALocalRun/
 
 # Config file
 config.json
+
+# Docker environment file
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0.401 AS build-env
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY Ranker/*.csproj ./
+RUN dotnet restore
+
+# Copy source code and build
+COPY Ranker ./
+RUN dotnet build -c Release -o out
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/runtime:5.0.10-alpine3.13
+WORKDIR /app
+COPY --from=build-env /app/out .
+ENTRYPOINT ["dotnet", "Ranker.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     volumes:
       - type: bind
         source: ./Ranker/config.json
-        target: /app/config.jsom
+        target: /app/config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2.3'
+services:
+  bot:
+    build: .
+    env_file:
+      - .env
+    restart: on-failure
+    volumes:
+      - type: bind
+        source: ./Ranker/config.json
+        target: /app/config.jsom


### PR DESCRIPTION
To run Ranker with Docker:
- Clone repo
- Make `.env` with `RANKER_TOKEN=tokenhere` where `tokenhere` is the bots token
- Create `Ranker/config.json` as normal
- Run `docker-compose up`, or add `-d` to fork to background

One idea for future would be creating an image on GitHub Container Registry that's built with a GitHub Action similar to Cliptok. But since Docker isn't the main focus for this project, the way it is now should be fine.