### PR TITLE
docker: Persist data in compose, fix Fleuron fonts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ config.json
 .env*
 *.md
 *.yml
+data/*

--- a/.gitignore
+++ b/.gitignore
@@ -407,5 +407,7 @@ ASALocalRun/
 # Config file
 config.json
 
-# Docker environment file
+# Docker data
 .env
+data/*
+!data/.gitkeep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     restart: on-failure
     volumes:
       - type: bind
+        source: ./data
+        target: /root/.ranker
+      - type: bind
         source: ./Ranker/config.json
         target: /app/config.json
     ports:


### PR DESCRIPTION
Docker setup should be properfly working now. Data will persist in `data/Ranker.db` and Fonts are copied over to the image so rank cards work perfectly.

You could rename the `data` folder to something else, I didn't think it would be very neat to map it to the users home directory which was the alternative solution. Up to you.